### PR TITLE
add basic publish function

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,13 @@ pnpm i
 ### 2. 编译共享模块
 
 ```
-cd packages/shared
-pnpm run build
+cd packages/shared && pnpm run build && cd ../..
 ```
 
 ### 3. 启动编辑器
 
 ```
-cd apps/editor
-pnpm i
-pnpm run dev
+cd apps/editor && pnpm i && pnpm run dev && cd ../..
 ```
 
 服务启动后进入[http://127.0.0.1:5173/editor]()以查看编辑器

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@lowcode512/shared": "workspace:^1.0.0",
+    "axios": "^0.27.2",
     "element-plus": "^2.2.14",
     "pinia": "^2.0.17",
     "tiny-emitter": "^2.1.0",

--- a/apps/editor/src/pages/editor/components/EditorHeader/EditorHeader.vue
+++ b/apps/editor/src/pages/editor/components/EditorHeader/EditorHeader.vue
@@ -1,59 +1,81 @@
 <script setup lang="ts">
-import { useProjectStore } from "@/store";
-import { useRouter } from "vue-router";
+import {useProjectStore} from "@/store";
+import {useRouter} from "vue-router";
+
 const projectStore = useProjectStore();
 const route = useRouter();
 import "./EditorHeader.less"
+import axios from "axios";
+import {postReqJson, produceReqJson} from "@/store/httpReq";
+import {router} from "@/router";
 
 function onSave() {
-    projectStore.saveProject();
+  projectStore.saveProject();
 }
 
 function onPreview() {
-    route.push("/preview");
+  route.push("/preview");
 }
 
 function onReset() {
-    projectStore.resetProject();
+  projectStore.resetProject();
 }
 
 function onUndo() {
-    projectStore.undo()
+  projectStore.undo()
 }
 
 function onRedo() {
-    projectStore.redo()
+  projectStore.redo()
 }
 
 function onCopy() {
-    projectStore.copyElement();
+  projectStore.copyElement();
 }
 
 function onPaste() {
-    projectStore.pasteElement();
+  projectStore.pasteElement();
 }
 
 function onRemove() {
-    projectStore.removeElement();
+  projectStore.removeElement();
 }
 
 function onCut() {
-    projectStore.cutElement();
+  projectStore.cutElement();
 }
 
+function onPublish() {
+  //projectStore.saveProject();
+  let projectData = projectStore.publishProject();
+  let reqJson = produceReqJson()
+  reqJson.type = "save"
+  reqJson.project_data = JSON.stringify(projectData)
+  postReqJson(reqJson).then((response) => {
+    let responseJson = response.data
+    if (!responseJson.status || responseJson.status != 200) {
+      console.log(`请求失败 ${responseJson}`)
+      alert("保存失败")
+      return
+    }
+    alert(`保存成功`)
+    router.push(`publish/${responseJson.project_id}`)
+  })
+}
 </script>
 
 
 <template>
-    <div class="editor-content-header">
-        <a-button type="outline" @click="onCopy">复制</a-button>
-        <a-button type="outline" @click="onPaste">粘贴</a-button>
-        <a-button type="outline" @click="onCut">剪切</a-button>
-        <a-button type="outline" @click="onRemove" status='danger'>删除</a-button>
-        <a-button type="outline" @click="onUndo">后退</a-button>
-        <a-button type="outline" @click="onRedo">前进</a-button>
-        <a-button type="outline" @click="onSave">保存</a-button>
-        <a-button type="outline" @click="onPreview">预览</a-button>
-        <a-button type="outline" @click="onReset">重置</a-button>
-    </div>
+  <div class="editor-content-header">
+    <a-button type="outline" @click="onCopy">复制</a-button>
+    <a-button type="outline" @click="onPaste">粘贴</a-button>
+    <a-button type="outline" @click="onCut">剪切</a-button>
+    <a-button type="outline" @click="onRemove" status='danger'>删除</a-button>
+    <a-button type="outline" @click="onUndo">后退</a-button>
+    <a-button type="outline" @click="onRedo">前进</a-button>
+    <a-button type="outline" @click="onSave">保存</a-button>
+    <a-button type="outline" @click="onPreview">预览</a-button>
+    <a-button type="outline" @click="onReset" status="danger">重置</a-button>
+    <a-button type="outline" @click="onPublish">发布</a-button>
+  </div>
 </template>

--- a/apps/editor/src/pages/preview/index.vue
+++ b/apps/editor/src/pages/preview/index.vue
@@ -1,9 +1,10 @@
 <template>
     <div class="page">
-        <div v-if="loading">loading...</div>
+        <div>{{project}}</div>
+        <div v-if="!project">loading...</div>
         <div
             v-else
-            v-for="item in pages[0].elements"
+            v-for="item in project.pages[page_index].elements"
             :key="item.id"
             :style="{
                 position: 'absolute',
@@ -26,11 +27,49 @@ import { IProject } from "@lowcode512/shared";
 import { materialMap } from "@/data";
 import { useMaterial } from "./material";
 import "./index.less";
+import axios from "axios";
+import {router} from "../../router.ts"
+import {onBeforeMount, onMounted, reactive, ref} from "vue";
+import {produceReqJson, postReqJson} from "@/store/httpReq";
 
-const { loading, pages } = useMaterial();
+// const {loading, pages} = useMaterial()
+let project = ref(JSON.parse(localStorage.getItem("__project") || "{}") as IProject)
+let page_index = ref(0)
 
-const project: IProject = JSON.parse(localStorage.getItem("__project") || "{}");
-console.log(project);
+onBeforeMount(async () => {
+  const backend_url = "/api/fetchProjectData"
+  const reqJsonTemplate = {
+    type: "read",
+    project_id: "",
+    project_data: "",
+    note: ""
+  }
+  let id = router.currentRoute.value.params.id
+  let page = router.currentRoute.value.params.page
+  if(!id){
+    return
+  }
+  let reqJson = produceReqJson()
+  reqJson.project_id = id
+  reqJson.type = "read"
+  postReqJson(reqJson).then((response) => {
+    let responseJson = response.data
+    if (!responseJson.status || responseJson.status != 200) {
+      console.log(`请求失败 ${responseJson}`)
+      return
+    }
+    let projectTmp = JSON.parse(responseJson.project_data) as IProject
+    if(!projectTmp || !projectTmp.pages ||!projectTmp.pages.length){
+      return
+    }
+    project.value = projectTmp
+    if(!page || page < 0 || page >= project.value.pages.length){
+      return
+    }
+    page_index.value = page
+  })
+})
+
 </script>
 
 <style scoped></style>

--- a/apps/editor/src/router.ts
+++ b/apps/editor/src/router.ts
@@ -1,5 +1,16 @@
 import { createRouter, createWebHistory } from "vue-router";
 import routes from "~pages";
+import Preview from "./pages/preview/index.vue"
+
+// 生成页面的地址
+routes.push({
+    path: "/publish/:id/:page",
+    component: Preview,
+})
+routes.push({
+    path: "/publish/:id",
+    component: Preview,
+})
 
 export const router = createRouter({
     history: createWebHistory(),

--- a/apps/editor/src/store/httpReq.ts
+++ b/apps/editor/src/store/httpReq.ts
@@ -1,0 +1,32 @@
+import axios from "axios";
+
+const backend_data_url = "/api/fetchProjectData"
+
+export type DataReqJson = {
+    type: string,
+    project_id: string,
+    project_data: string,
+    note: string
+}
+
+export const produceReqJson = function (type?, id?, data?, note?) {
+    return {
+        type: type || "",
+        project_id: id || "",
+        project_data: data || "",
+        note: note || ""
+    } as DataReqJson
+}
+export const postReqJson = function(reqJson: DataReqJson){
+    return axios({
+        method: "post",
+        data: JSON.stringify(reqJson),
+        url: backend_data_url,
+        headers: {
+            "Content-Type": "application/json"
+        },
+        transformRequest: [
+            data => {return data}
+        ]
+    })
+}

--- a/apps/editor/src/store/project.ts
+++ b/apps/editor/src/store/project.ts
@@ -127,15 +127,10 @@ export const useProjectStore = defineStore("project", () => {
 
     function resetProject() {
         p = project.value = Project.create();
-        saveProject();
-        // sorry for doing that, but i don't really understand the structure for now
-        // so i choose this way to refresh page
-        // router.push("/").then( () => {
-        //         setTimeout(() => {
-        //             router.push("/editor")
-        //         }, 200)
-        //     }
-        // )
+    }
+
+    function publishProject() {
+        return p.getJson()
     }
 
     function setCurrentPageIndex(index: number) {
@@ -278,6 +273,7 @@ export const useProjectStore = defineStore("project", () => {
 
         saveProject,
         resetProject,
+        publishProject,
 
         saveSnapshot,
         undo,

--- a/apps/editor/vite.config.ts
+++ b/apps/editor/vite.config.ts
@@ -15,15 +15,21 @@ export default defineConfig({
         ),
         vue(),
         Pages({ exclude: ["**/components/*"] }),
-        viteMocker({
-            // 请求响应延迟时间区间
-            delay: [0, 1000],
-        }) as unknown as PluginOption,
     ],
 
     define: {
         "process.env": process.env,
     },
+
+    server: {
+        proxy: {
+        // 请求项目json
+            '/api/fetchProjectData': {
+                target: "http://localhost:5197",
+                changeOrigin: true,
+            }
+        }
+    }
     // resolve: {
     //     alias: {
     //         "@": path.resolve(__dirname, "src"),

--- a/package.json
+++ b/package.json
@@ -23,8 +23,5 @@
   },
   "scripts": {
     "build": "vite build"
-  },
-  "dependencies": {
-    "qs": "^6.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   },
   "scripts": {
     "build": "vite build"
+  },
+  "dependencies": {
+    "qs": "^6.11.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,7 @@ importers:
     specifiers:
       '@arco-design/web-vue': ^2.35.0
       '@lowcode512/shared': workspace:^1.0.0
+      axios: ^0.27.2
       element-plus: ^2.2.14
       pinia: ^2.0.17
       tiny-emitter: ^2.1.0
@@ -53,6 +54,7 @@ importers:
       vue-router: ^4.1.3
     dependencies:
       '@lowcode512/shared': link:../../packages/shared
+      axios: 0.27.2
       element-plus: 2.2.14_vue@3.2.37
       pinia: 2.0.17_vue@3.2.37
       tiny-emitter: 2.1.0
@@ -83,17 +85,7 @@ importers:
       '@lowcode512/shared': 'link:'
 
   packages/slider:
-    specifiers:
-      '@arco-design/web-vue': ^2.35.0
-      '@vitejs/plugin-vue': ^3.0.1
-      element-plus: ^2.2.14
-      vue: ^3.2.37
-    dependencies:
-      element-plus: 2.2.14_vue@3.2.37
-      vue: 3.2.37
-    devDependencies:
-      '@arco-design/web-vue': 2.35.0_vue@3.2.37
-      '@vitejs/plugin-vue': 3.0.1_vite@3.0.4+vue@3.2.37
+    specifiers: {}
 
   packages/title:
     specifiers: {}
@@ -732,7 +724,7 @@ packages:
       vite: ^3.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 3.0.4
+      vite: 3.0.4_less@4.1.3
       vue: 3.2.37
     dev: true
 
@@ -905,10 +897,23 @@ packages:
     resolution: {integrity: sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==}
     dev: false
 
+  /asynckit/0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: false
+
   /available-typed-arrays/1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
     dev: true
+
+  /axios/0.27.2:
+    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
+    dependencies:
+      follow-redirects: 1.15.1
+      form-data: 4.0.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /b-tween/0.3.3:
     resolution: {integrity: sha512-oEHegcRpA7fAuc9KC4nktucuZn2aS8htymCPcP3qkEGPqiBH+GfqtqoG2l7LxHngg6O0HFM7hOeOYExl1Oz4ZA==}
@@ -1072,6 +1077,13 @@ packages:
       color-string: 1.9.1
     dev: true
 
+  /combined-stream/1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: false
+
   /commondir/1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
     dev: true
@@ -1192,6 +1204,11 @@ packages:
   /defu/6.0.0:
     resolution: {integrity: sha512-t2MZGLf1V2rV4VBZbWIaXKdX/mUcYW0n2znQZoADBkGGxYL8EWqCuCZBmJPJ/Yy9fofJkyuuSuo5GSwo0XdEgw==}
     dev: true
+
+  /delayed-stream/1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+    dev: false
 
   /dir-glob/3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -1764,11 +1781,30 @@ packages:
     resolution: {integrity: sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==}
     dev: true
 
+  /follow-redirects/1.15.1:
+    resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
       is-callable: 1.2.4
     dev: true
+
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
 
   /fs-extra/10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -2340,6 +2376,18 @@ packages:
       braces: 3.0.2
       picomatch: 2.3.1
     dev: true
+
+  /mime-db/1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-types/2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: false
 
   /mime/1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -3230,33 +3278,6 @@ packages:
     dependencies:
       esbuild: 0.14.53
       less: 4.1.3
-      postcss: 8.4.16
-      resolve: 1.22.1
-      rollup: 2.77.2
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
-  /vite/3.0.4:
-    resolution: {integrity: sha512-NU304nqnBeOx2MkQnskBQxVsa0pRAH5FphokTGmyy8M3oxbvw7qAXts2GORxs+h/2vKsD+osMhZ7An6yK6F1dA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.14.53
       postcss: 8.4.16
       resolve: 1.22.1
       rollup: 2.77.2


### PR DESCRIPTION
加入了基本的发布功能：可以在编辑器页面“发布”，然后跳转到发布地址

[后端](https://github.com/heartD-bytesD/low-code-backend)相应进行了更新，把原来的api分到一个path上，方便后续扩展

需要后续改进的地方：
1. 发布地址能正确读出保存在后端的project的json数据，但渲染时生成的dom不正确，导致页面空白，所以把projectJson打印到了页面上; 不影响预览功能
2. 暂时没有支持在发布项目的id上继续进行编辑而不生成新id
3. 缺少一个列出所有保存的项目的api