### PR TITLE
preview & publish: implement more publish and preview function

### DIFF
--- a/apps/editor/src/pages/preview/index.vue
+++ b/apps/editor/src/pages/preview/index.vue
@@ -1,76 +1,131 @@
 <template>
     <div class="page">
-        <div>{{project}}</div>
-        <div v-if="!project">loading...</div>
-        <div
-            v-else
-            v-for="item in project.pages[page_index].elements"
-            :key="item.id"
-            :style="{
+      <a-alert v-if="loading" :title="loadingAlert"></a-alert>
+      <div
+          v-else
+          v-for="item in page.elements"
+          :key="item.id"
+          :style="{
                 position: 'absolute',
                 left: item.style.left + 'px',
                 top: item.style.top + 'px',
                 width: item.style.width + 'px',
                 height: item.style.height + 'px',
             }"
-        >
-            <component
-                :is="materialMap[item.mId].name"
-                v-bind="item.props"
-            ></component>
-        </div>
+      >
+        <component
+            :is="materialMap[item.mId].name"
+            v-bind="item.props"
+        ></component>
+      </div>
     </div>
+  <a-card v-if="!loading" :title='project.name + " - 第" + (pageIndex + 1) + "页 - " + page.name' >
+      <a-menu class="ls-preview-menu">
+        <a-menu-item v-for="[mIndex, _] in project.pages.entries()" @click="pageChange(mIndex)">
+          <a>第{{mIndex+1}}页</a>
+        </a-menu-item>
+      </a-menu>
+  </a-card>
 </template>
 
 <script setup lang="ts">
-import { useHttpReqStore } from "@/store";
-import { IProject } from "@lowcode512/shared";
-import { materialMap } from "@/data";
+import {useHttpReqStore} from "@/store";
+import {IProject, Project} from "@lowcode512/shared";
+import {getMaterialRenderFun, materialMap} from "@/data";
 import "./index.less";
-import {router} from "../../router"
-import {onBeforeMount, ref} from "vue";
+import {router} from "@/router"
+import {onBeforeMount, onMounted, ref} from "vue";
+import {loadMaterial} from "@/utils";
+import app from "@/app";
 
-// const {loading, pages} = useMaterial()
-let project = ref(JSON.parse(localStorage.getItem("__project") || "{}") as IProject)
-let page_index = ref(0)
+let loading = ref(true)
+let loadingAlert = ref("加载中...")
+let page = ref({name: "", elements:[]})
+let project = ref(Project.create())
+let pageIndex = ref(0)
+let pageNumber = ref(project.value.pages.length)
+let isPreviewPage = ref(window.location.href.includes("preview"))
+if(isPreviewPage.value){
+  project.value = JSON.parse(localStorage.getItem("__project") || "{}") as IProject
+  page.value = project.value.pages[pageIndex.value]
+  pageNumber.value = project.value.pages.length
+}
+
+// router.currentRoute.value.params有可能是空对象
+let projectId = null
+if(router.currentRoute.value.params){
+  projectId = router.currentRoute.value.params.id;
+  pageIndex.value = Number(router.currentRoute.value.params.pageIndex) || 0;
+}
+
 let httpReqStore = useHttpReqStore();
-onBeforeMount(async () => {
-  const backend_url = "/api/fetchProjectData"
-  const reqJsonTemplate = {
-    type: "read",
-    project_id: "",
-    project_data: "",
-    note: ""
-  }
-  // router.currentRoute.value.params有可能是空对象
-  let id = router.currentRoute.value.params.id || 0;
-  let page = router.currentRoute.value.params.page || 0;
-  console.log("page: " , router.currentRoute)
-  if(!id){
+// 加载项目json文件
+const loadOnlineJson = async () => {
+  console.log("pageRouter: " , router.currentRoute)
+  if(!projectId){
     return
   }
   let reqJson = httpReqStore.produceReqJson()
-  reqJson.project_id = id as string
+  reqJson.project_id = projectId as string
   reqJson.type = "read"
-  httpReqStore.postReqJson(reqJson).then((response) => {
+  return httpReqStore.postReqJson(reqJson).then((response) => {
     let responseJson = response.data
     if (!responseJson.status || responseJson.status != 200) {
       console.log(`请求失败 ${responseJson}`)
       return
     }
+    console.info("读取到远程保存的项目数据: " , responseJson.project_data)
     let projectTmp = JSON.parse(responseJson.project_data) as IProject
     if(!projectTmp || !projectTmp.pages ||!projectTmp.pages.length){
       return
     }
-    project.value = projectTmp
-    if(!page || page < 0 || page >= project.value.pages.length){
-      return
+    if(pageIndex.value >= projectTmp.pages.length){
+      throw new DOMException("不存在此页")
     }
-    // 这块page是string | number | string[]，留意一下是否需要更严格的类型检验
-    page_index.value = page as number;
+    // 这块pageIndex是string | number | string[]，留意一下是否需要更严格的类型检验
+    project.value = projectTmp
+    pageNumber.value = project.value.pages.length
+  })
+}
+// 加载页面脚本
+onBeforeMount(async () => {
+  loadOnlineJson().then(() => {
+    const pageTmp = project.value.pages[pageIndex.value]
+    console.log("当前页面使用的项目数据: ", project.value)
+    const materials = pageTmp.elements.map(item =>
+        materialMap[item.mId]
+    )
+    loading.value = true;
+    Promise.all(Object.values(materials).map(loadMaterial)).then(() => {
+      loading.value = false;
+      materials.forEach(m => {
+        app.component(m.name, getMaterialRenderFun(m))
+      })
+      page.value = pageTmp
+    });
+  }, (err) => {
+    loadingAlert.value = `${err}`
   })
 })
 
+// 切换页面
+let pageChange = function (nextPageIndex) {
+  if(isPreviewPage.value){
+    window.location.assign(`/preview/${nextPageIndex}`)
+  }else{
+    window.location.assign(`/publish/${projectId}/${nextPageIndex}`)
+  }
+}
+
 </script>
 
-<style scoped></style>
+<style scoped>
+.ls-preview-menu{
+  opacity: 0;
+  transition: opacity 1.0s;
+}
+.ls-preview-menu:hover{
+  opacity: 100%;
+  transition: opacity 1.0s;
+}
+</style>

--- a/apps/editor/src/pages/preview/index.vue
+++ b/apps/editor/src/pages/preview/index.vue
@@ -21,8 +21,8 @@
     </div>
   <a-card v-if="!loading" :title='project.name + " - 第" + (pageIndex + 1) + "页 - " + page.name' >
       <a-menu class="ls-preview-menu">
-        <a-menu-item v-for="[mIndex, _] in project.pages.entries()" @click="pageChange(mIndex)">
-          <a>第{{mIndex+1}}页</a>
+        <a-menu-item v-for="[mIndex, mPage] in project.pages.entries()" @click="pageChange(mIndex)">
+          <a>第{{mIndex+1}}页 - {{mPage.name}}</a>
         </a-menu-item>
       </a-menu>
   </a-card>

--- a/apps/editor/src/pages/preview/index.vue
+++ b/apps/editor/src/pages/preview/index.vue
@@ -34,23 +34,29 @@ import {IProject, Project} from "@lowcode512/shared";
 import {getMaterialRenderFun, materialMap} from "@/data";
 import "./index.less";
 import {router} from "@/router"
-import {onBeforeMount, onMounted, ref} from "vue";
+import {onBeforeMount, ref} from "vue";
 import {loadMaterial} from "@/utils";
 import app from "@/app";
 
+// 加载中的状态
 let loading = ref(true)
+// 加载中或出错的文字提示
 let loadingAlert = ref("加载中...")
+// 显示的页面数据
 let page = ref({name: "", elements:[]})
+// 当前页面对应的项目数据
 let project = ref(Project.create())
+// 当前页面对应的项目数据中的页码
 let pageIndex = ref(0)
-let pageNumber = ref(project.value.pages.length)
+// 是否为预览页面
 let isPreviewPage = ref(window.location.href.includes("preview"))
+// 如果是，加载本地存储
 if(isPreviewPage.value){
   project.value = JSON.parse(localStorage.getItem("__project") || "{}") as IProject
   page.value = project.value.pages[pageIndex.value]
-  pageNumber.value = project.value.pages.length
 }
 
+// 读取页面参数
 // router.currentRoute.value.params有可能是空对象
 let projectId = null
 if(router.currentRoute.value.params){
@@ -84,7 +90,6 @@ const loadOnlineJson = async () => {
     }
     // 这块pageIndex是string | number | string[]，留意一下是否需要更严格的类型检验
     project.value = projectTmp
-    pageNumber.value = project.value.pages.length
   })
 }
 // 加载页面脚本
@@ -120,6 +125,7 @@ let pageChange = function (nextPageIndex) {
 </script>
 
 <style scoped>
+/* 菜单淡入淡出 */
 .ls-preview-menu{
   opacity: 0;
   transition: opacity 1.0s;

--- a/apps/editor/src/pages/preview/index.vue
+++ b/apps/editor/src/pages/preview/index.vue
@@ -115,6 +115,9 @@ onBeforeMount(async () => {
 
 // 切换页面
 let pageChange = function (nextPageIndex) {
+  if(nextPageIndex == pageIndex.value){
+    return
+  }
   if(isPreviewPage.value){
     window.location.assign(`/preview/${nextPageIndex}`)
   }else{

--- a/apps/editor/src/router.ts
+++ b/apps/editor/src/router.ts
@@ -4,12 +4,16 @@ import Preview from "./pages/preview/index.vue"
 
 // 生成页面的地址
 routes.push({
-    path: "/publish/:id/:page",
+    path: "/publish/:id/:pageIndex",
     component: Preview,
-})
-routes.push({
+},{
     path: "/publish/:id",
     component: Preview,
+})
+// 预览页面的地址
+routes.push({
+    path: "/preview/:pageIndex",
+    component: Preview
 })
 
 export const router = createRouter({

--- a/apps/editor/src/store/project.ts
+++ b/apps/editor/src/store/project.ts
@@ -18,10 +18,10 @@ export let p = computed(() => {
     // JSON.parse(localStorage.getItem("__project") || "{}");
     let pJson = localStorage.getItem(LOCAL_STORAGE_PROJECT);
     if (!pJson) {
-        console.info("没有已保存的项目数据");
+        console.info("本地没有已保存的项目数据");
         return Project.create();
     }
-    console.info(`读取到已保存的项目数据: ${pJson}`);
+    console.info(`读取到本地已保存的项目数据: ${pJson}`);
     return Project.create(JSON.parse(pJson));
 }).value as Project;
 


### PR DESCRIPTION
1. 将`preview/material.ts`的实现整合到`preview/index.vue`，完善了发布功能，现在可以正常显示发布页面和预览页面
2. 在预览页面和发布页面底部增加了切换页面的菜单
3. 优化了加载提示，新增路由路径等等